### PR TITLE
Enable exporting to a directory as txt files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,9 @@ its name, is a much simpler approach. It just stores your plain text
 notes, and that is it.
 
 This package installs a script to help you migrate from Evernote into
-Simplenote using the standard Simplenote import options. The script
-will take an Evernote ``enex`` export and turn it into a ``json`` or
-``csv`` file compatible with Simplenote.
+Simplenote by exporting the notes as files. The script
+will take an Evernote ``enex`` export and turn it into a ``json``, ``csv`` or
+directory of ``*.txt`` files.
 
 The html that is provided by Evernote is processed by the html2text_
 library. This transforms the html into Markdown_. The Simplenote web UI
@@ -29,6 +29,21 @@ follows (preferably in a virtualenv)::
 
     $ pip install -U ever2simple
 
+Development Installation
+------------------------
+
+Clone this repository with ``git``::
+
+    $ git clone https://github...
+
+Enter the code directory::
+
+    $ cd ever2simple
+
+Install live preserving local changes to the code::
+
+    $ pip install -e .
+
 Usage
 -----
 
@@ -38,25 +53,65 @@ This can be done from the desktop client. You can select the notes you
 want to export, then ``Export Notes to Archive...``, and select the
 ``enex`` format.
 
-Once you have that, you can run the script on the file::
+Once you have that, you can run the script on the file setting the ``--output``
+to a directory and using ``dir`` as the parameter to ``--format``::
 
-    $ ever2simple my_evernote.enex > simplenote.json
+    $ ever2simple my_evernote.enex --output simplenote_dir --format dir
 
-Right now it just outputs the data to ``stdout``, so you can just output
-directly to the file of your choosing (in this case ``simplenote.json``).
+That will output each note in a ``*.txt`` file named by a number to the
+``simplenote_dir`` directory (creating it if it doesn't exist).
 
-Now you can go to the Simplenote website and import the newly created
-``json`` file.
+You can now request Simplenote's support to enable Dropbox synchronization
+to your account here: https://simplenote.com/contact-us/
+
+Once they enable Dropbox synchronization for you, go to
+https://app.simplenote.com/settings and configure it (in the last section).
+
+After that, copy your converted ``*.txt`` note files to your Simplenote
+directory inside your Dropbox and synchronize them from
+https://app.simplenote.com/settings.
+
+
+If you want to export to CSV you can pass ``csv`` to the ``--format``
+parameter::
+
+    $ ever2simple my_evernote.enex --output simplenote.csv --format csv
+
+If you want to export to JSON you can pass ``json`` to the ``--format``
+parameter (or just don't use that parameter as ``json`` is the default)::
+
+    $ ever2simple my_evernote.enex --output simplenote.json --format json
+
+Command Line Help
+-----------------
+
+The help given by running ``ever2simple -h``::
+
+
+    usage: ever2simple [-h] [-o OUTPUT] [-f {json,csv,dir}] enex-file
+
+    Convert Evernote.enex files to Markdown
+
+    positional arguments:
+      enex-file             the path to the Evernote.enex file
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o OUTPUT, --output OUTPUT
+                            the path to the output file or directory, leave black
+                            to output to the terminal (stdout) (default: None)
+      -f {json,csv,dir}, --format {json,csv,dir}
+                            the output format, json, csv or a directory (default:
+                            json)
+
 
 Notes and Caveats
 -----------------
 
-There are some issues that you should be aware of when importing your
-notes.
+- Simplenote no longer supports JSON and CSV imports, only text files via
+  Dropbox.
 
-- There is already an Evernote importer on the Simplenote website, why
-  did you write this? A: The current enex importer is very badly broken
-  and duplicates your notes over and over. It is not recommended.
+- Exporting to a directory will not preserve tags in the notes.
 
 - This does not handle any attachments since simplenote doesn't support
   them. This script does not ignore the note that has attachments. This
@@ -86,9 +141,5 @@ TODO
 ----
 
 - Write some basic tests
-- Finish out the command line options
-  - Output file
-  - stdout option
-  - csv output
 - Unicode for ``DictWriter``
 - Test on Python 3

--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -20,7 +20,9 @@ class EverConverter(object):
         self.stdout = False
         if simple_filename is None:
             self.stdout = True
-        self.simple_filename = simple_filename
+            self.simple_filename = simple_filename
+        else:
+            self.simple_filename = os.path.expanduser(simple_filename)
         self.fmt = fmt
 
     def _load_xml(self, enex_file):
@@ -80,6 +82,8 @@ class EverConverter(object):
             self._convert_csv(notes)
         if self.fmt == 'json':
             self._convert_json(notes)
+        if self.fmt == 'dir':
+            self._convert_dir(notes)
 
     def _convert_html_markdown(self, title, text):
         html2plain = HTML2Text(None, "")
@@ -104,4 +108,19 @@ class EverConverter(object):
         if self.simple_filename is None:
             sys.stdout.write(json.dumps(notes))
         else:
-            json.dump(notes, self.simple_filename)
+            with open(self.simple_filename, 'w') as output_file:
+                json.dump(notes, output_file)
+
+    def _convert_dir(self, notes):
+        if self.simple_filename is None:
+            sys.stdout.write(json.dumps(notes))
+        else:
+            if os.path.exists(self.simple_filename) and not os.path.isdir(self.simple_filename):
+                print '"%s" exists but is not a directory. %s' % self.simple_filename
+                sys.exit(1)
+            elif not os.path.exists(self.simple_filename):
+                os.makedirs(self.simple_filename)
+            for i, note in enumerate(notes):
+                output_file_path = os.path.join(self.simple_filename, str(i) + '.txt')
+                with open(output_file_path, 'w') as output_file:
+                    output_file.write(note['content'].encode(encoding='utf-8'))

--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -41,8 +41,12 @@ class EverConverter(object):
             title = note.xpath('title')[0].text
             # Use dateutil to figure out these dates
             # 20110610T182917Z
-            created_string = parse(note.xpath('created')[0].text)
-            updated_string = parse(note.xpath('updated')[0].text)
+            created_string = parse('19700101T000017Z')
+            if note.xpath('created'):
+                created_string = parse(note.xpath('created')[0].text)
+            updated_string = created_string
+            if note.xpath('updated'):
+                updated_string = parse(note.xpath('updated')[0].text)
             note_dict['createdate'] = created_string.strftime(self.date_fmt)
             note_dict['modifydate'] = updated_string.strftime(self.date_fmt)
             tags = [tag.text for tag in note.xpath('tag')]

--- a/ever2simple/core.py
+++ b/ever2simple/core.py
@@ -1,18 +1,23 @@
 import os
 import sys
 from ever2simple.converter import EverConverter
+import argparse
 
 
 def main():
-    args = sys.argv[1:]
-    if len(args) != 1:
-        print 'Usage: ever2simple <enex_file>'
-        sys.exit(1)
-    filepath = os.path.expanduser(args[0])
+    parser = argparse.ArgumentParser(prog=None, description="Convert Evernote.enex files to Markdown", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('enex-file', help="the path to the Evernote.enex file")
+    parser.add_argument('-o', '--output', help="the path to the output file or directory, leave black to output to the terminal (stdout)")
+    parser.add_argument('-f', '--format', help="the output format, json, csv or a directory", choices=['json', 'csv', 'dir'], default='json')
+    args = parser.parse_args()
+    enex_file = vars(args)['enex-file']
+    output = args.output
+    fmt = args.format
+    filepath = os.path.expanduser(enex_file)
     if not os.path.exists(filepath):
         print 'File does not exist: %s' % filepath
         sys.exit(1)
-    converter = EverConverter(filepath)
+    converter = EverConverter(filepath, simple_filename=output, fmt=fmt)
     converter.convert()
     sys.exit()
 


### PR DESCRIPTION
Enable exporting to a directory as `*.txt` Markdown files, as currently, the only way to import is by asking for Dropbox synchronization and adding the notes as text files to the Simplenote directory in Dropbox.

Update the instructions in the README to include that.

Include the fix done by @austinjp for dates as it wasn't working without it.

Update and improve the command line interface, allowing to export to CSV, JSON and a directory of Markdown files, additionally to outputting to the `stdout`.
