### PR TITLE
Make strftime() string portable

### DIFF
--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -13,7 +13,7 @@ class EverConverter(object):
     """
 
     fieldnames = ['createdate', 'modifydate', 'content', 'tags']
-    date_fmt = '%h %d %Y %H:%M:%S'
+    date_fmt = '%b %d %Y %H:%M:%S'
 
     def __init__(self, enex_filename, simple_filename=None, fmt='json'):
         self.enex_filename = os.path.expanduser(enex_filename)

--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -1,6 +1,8 @@
 import json
 import os
 import sys
+import datetime
+import pytz
 from csv import DictWriter
 from cStringIO import StringIO
 from dateutil.parser import parse
@@ -15,7 +17,7 @@ class EverConverter(object):
     fieldnames = ['createdate', 'modifydate', 'content', 'tags']
     date_fmt = '%b %d %Y %H:%M:%S'
 
-    def __init__(self, enex_filename, simple_filename=None, fmt='json'):
+    def __init__(self, enex_filename, simple_filename=None, fmt='json', epoch=False):
         self.enex_filename = os.path.expanduser(enex_filename)
         self.stdout = False
         if simple_filename is None:
@@ -24,6 +26,7 @@ class EverConverter(object):
         else:
             self.simple_filename = os.path.expanduser(simple_filename)
         self.fmt = fmt
+        self.epoch = epoch
 
     def _load_xml(self, enex_file):
         try:
@@ -49,8 +52,12 @@ class EverConverter(object):
             updated_string = created_string
             if note.xpath('updated'):
                 updated_string = parse(note.xpath('updated')[0].text)
-            note_dict['createdate'] = created_string.strftime(self.date_fmt)
-            note_dict['modifydate'] = updated_string.strftime(self.date_fmt)
+            if self.epoch:
+                note_dict['createdate'] = int((created_string - datetime.datetime(1970,1,1,tzinfo=pytz.utc)).total_seconds())
+                note_dict['modifydate'] = int((updated_string - datetime.datetime(1970,1,1,tzinfo=pytz.utc)).total_seconds())
+            else:
+                note_dict['createdate'] = created_string.strftime(self.date_fmt)
+                note_dict['modifydate'] = updated_string.strftime(self.date_fmt)
             tags = [tag.text for tag in note.xpath('tag')]
             if self.fmt == 'csv':
                 tags = " ".join(tags)

--- a/ever2simple/converter.py
+++ b/ever2simple/converter.py
@@ -113,14 +113,14 @@ class EverConverter(object):
 
     def _convert_json(self, notes):
         if self.simple_filename is None:
-            sys.stdout.write(json.dumps(notes))
+            sys.stdout.write(json.dumps(notes, sort_keys=True, indent=4, separators=(',', ': ')))
         else:
             with open(self.simple_filename, 'w') as output_file:
-                json.dump(notes, output_file)
+                json.dump(notes, output_file, sort_keys=True, indent=4, separators=(',', ': '))
 
     def _convert_dir(self, notes):
         if self.simple_filename is None:
-            sys.stdout.write(json.dumps(notes))
+            sys.stdout.write(json.dumps(notes, sort_keys=True, indent=4, separators=(',', ': ')))
         else:
             if os.path.exists(self.simple_filename) and not os.path.isdir(self.simple_filename):
                 print '"%s" exists but is not a directory. %s' % self.simple_filename

--- a/ever2simple/core.py
+++ b/ever2simple/core.py
@@ -9,6 +9,7 @@ def main():
     parser.add_argument('enex-file', help="the path to the Evernote.enex file")
     parser.add_argument('-o', '--output', help="the path to the output file or directory, leave black to output to the terminal (stdout)")
     parser.add_argument('-f', '--format', help="the output format, json, csv or a directory", choices=['json', 'csv', 'dir'], default='json')
+    parser.add_argument('-e', '--epoch', help="Write dates UNIX timestamp format", action="store_true")
     args = parser.parse_args()
     enex_file = vars(args)['enex-file']
     output = args.output
@@ -17,7 +18,7 @@ def main():
     if not os.path.exists(filepath):
         print 'File does not exist: %s' % filepath
         sys.exit(1)
-    converter = EverConverter(filepath, simple_filename=output, fmt=fmt)
+    converter = EverConverter(filepath, simple_filename=output, fmt=fmt, epoch=args.epoch)
     converter.convert()
     sys.exit()
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         'lxml',
         'python-dateutil<2.0',
         'html2text',
+        'pytz'
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
%h is not a valid keyword in python strftime() format. Use %b instead

(Fixes issue #6)
